### PR TITLE
Fix header name

### DIFF
--- a/weatherAp.cpp
+++ b/weatherAp.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include <weatherAP.h>
+#include <weatherAp.h>
 
 weatherAP::weatherAP(WiFiClient* client) {
     _client = client;


### PR DESCRIPTION
For case-sensitive filesystems like the one Linux and Mac use. The file is called `weatherAp.h` and should be referred to with that name -- if it's not, this only works in Windows.